### PR TITLE
upgrade aws-chamber to terraform v0.12

### DIFF
--- a/aws-chamber/main.tf
+++ b/aws-chamber/main.tf
@@ -1,4 +1,5 @@
-provider "aws" {}
+provider "aws" {
+}
 
 resource "aws_kms_key" "parameter_store" {
   description             = "Parameter store kms master key"
@@ -8,50 +9,50 @@ resource "aws_kms_key" "parameter_store" {
 
 resource "aws_kms_alias" "parameter_store_alias" {
   name          = "alias/parameter_store_key"
-  target_key_id = "${aws_kms_key.parameter_store.id}"
+  target_key_id = aws_kms_key.parameter_store.id
 }
 
 data "aws_iam_policy_document" "kms_read_write" {
-  statement = {
+  statement {
     effect = "Allow"
     actions = [
       "kms:Encrypt",
-      "kms:Decrypt"
+      "kms:Decrypt",
     ]
-    resources = ["${aws_kms_key.parameter_store.arn}"]
+    resources = [aws_kms_key.parameter_store.arn]
   }
 }
 
 resource "aws_iam_policy" "kms_read_write" {
-  policy = "${data.aws_iam_policy_document.kms_read_write.json}"
+  policy = data.aws_iam_policy_document.kms_read_write.json
 }
 
 data "aws_iam_policy_document" "kms_read_only" {
-  statement = {
+  statement {
     effect = "Allow"
     actions = [
-      "kms:Decrypt"
+      "kms:Decrypt",
     ]
-    resources = ["${aws_kms_key.parameter_store.arn}"]
+    resources = [aws_kms_key.parameter_store.arn]
   }
 }
 
 resource "aws_iam_policy" "kms_read_only" {
-  policy = "${data.aws_iam_policy_document.kms_read_only.json}"
+  policy = data.aws_iam_policy_document.kms_read_only.json
 }
 
 resource "aws_iam_group" "chamber_group" {
-  name = "${var.group_name}"
+  name = var.group_name
 }
 
 resource "aws_iam_group_policy_attachment" "chamber_attach_ssm" {
-  group      = "${aws_iam_group.chamber_group.name}"
+  group      = aws_iam_group.chamber_group.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMFullAccess"
 }
 
 resource "aws_iam_group_policy_attachment" "chamber_attach_kms_read_write" {
-  group      = "${aws_iam_group.chamber_group.name}"
-  policy_arn = "${aws_iam_policy.kms_read_write.arn}"
+  group      = aws_iam_group.chamber_group.name
+  policy_arn = aws_iam_policy.kms_read_write.arn
 }
 
 resource "aws_iam_group" "chamber_group_read_only" {
@@ -59,11 +60,12 @@ resource "aws_iam_group" "chamber_group_read_only" {
 }
 
 resource "aws_iam_group_policy_attachment" "chamber_attach_ssm_read_only" {
-  group      = "${aws_iam_group.chamber_group_read_only.name}"
+  group      = aws_iam_group.chamber_group_read_only.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMFullAccess"
 }
 
 resource "aws_iam_group_policy_attachment" "chamber_attach_kms_read_only" {
-  group      = "${aws_iam_group.chamber_group_read_only.name}"
-  policy_arn = "${aws_iam_policy.kms_read_only.arn}"
+  group      = aws_iam_group.chamber_group_read_only.name
+  policy_arn = aws_iam_policy.kms_read_only.arn
 }
+

--- a/aws-chamber/vars.tf
+++ b/aws-chamber/vars.tf
@@ -1,4 +1,5 @@
 variable "group_name" {
   description = "The name of the administrator group"
-  default = "SecretKeepers"
+  default     = "SecretKeepers"
 }
+

--- a/aws-chamber/versions.tf
+++ b/aws-chamber/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
# Summary

Upgrades the aws-chamber module to support terraform v0.12. This code is modified using the terraform upgrade command:

`terraform 0.12upgrade`

# Test Plan

In the `aws-chamber` directory run
- `terraform -v` # ensure your version is > 0.12
- `terraform init`
- `terraform plan`

You should see all chamber resources that will be created (no syntax errors)

- Cleanup: Delete the terraform init files.
