### PR TITLE
Update bucket policy to be public

### DIFF
--- a/terraform-aws-static-site/main.tf
+++ b/terraform-aws-static-site/main.tf
@@ -15,15 +15,13 @@ data "aws_iam_policy_document" "non-www-bucket" {
 
     principals {
       type        = "AWS"
-      identifiers = [aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn,"*"]
+      identifiers = ["*"]
     }
 
     actions   = ["s3:GetObject"]
     resources = ["arn:aws:s3:::${var.bucket_name}/*"]
   }
 }
-
-resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {}
 
 resource "aws_s3_bucket_policy" "non-www-bucket" {
   bucket = aws_s3_bucket.non-www-bucket.id

--- a/terraform-aws-static-site/main.tf
+++ b/terraform-aws-static-site/main.tf
@@ -11,10 +11,11 @@ resource "aws_s3_bucket" "non-www-bucket" {
 data "aws_iam_policy_document" "non-www-bucket" {
   statement {
     effect = "Allow"
+    sid = "PublicReadGetObject"
 
     principals {
       type        = "AWS"
-      identifiers = [aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn]
+      identifiers = [aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn,"*"]
     }
 
     actions   = ["s3:GetObject"]


### PR DESCRIPTION
Without the '*', the website will automatically deny access and you need to manually set index.html as public in the s3 bucket manager.